### PR TITLE
Handle network errors more gracefully

### DIFF
--- a/src/currencyEngineETH.js
+++ b/src/currencyEngineETH.js
@@ -164,6 +164,9 @@ class EthereumEngine implements AbcCurrencyEngine {
     const response = await io.fetch(url, {
       method: 'GET'
     })
+    if (!response.ok) {
+      throw new Error(`The server returned error code ${response.status} for ${url}`)
+    }
     return response.json()
   }
 
@@ -181,6 +184,9 @@ class EthereumEngine implements AbcCurrencyEngine {
       method: 'POST',
       body: JSON.stringify(body)
     })
+    if (!response.ok) {
+      throw new Error(`The server returned error code ${response.status} for ${url}`)
+    }
     return response.json()
   }
 


### PR DESCRIPTION
If the server returns an error (such as a 404), but the error message just happens to be valid JSON, you will get weird errors later on in the program. This catches those cases and throws a proper exception.