### PR TITLE
Prevent corrupt nativeAmount in token transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-currency-ethereum",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Edge Ethereum currency plugin",
   "homepage": "https://edgesecure.co/",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/currencyEngineETH.js
+++ b/src/currencyEngineETH.js
@@ -329,7 +329,11 @@ class EthereumEngine {
       netNativeAmount = bns.add('0', tx.data)
       ourReceiveAddresses.push(this.walletLocalData.ethereumAddress.toLowerCase())
     }
-    // const nativeNetworkFee:string = bns.mul(tx.gasPrice, tx.gasUsed)
+
+    if (netNativeAmount.length > 50) {
+      // Etherscan occasionally send back a transactino with a corrupt amount in tx.data. Ignore this tx.
+      return
+    }
 
     const ethParams = new EthereumParams(
       [ fromAddress ],


### PR DESCRIPTION
Ignore transactions from Etherscan with tx.data value that doesn't appear to represent the nativeAmount value. They seem to always be followed by a transaction with the correct amount in tx.data.