### PR TITLE
Throw error in makeSpend if token tx doesn't have enough ETH

### DIFF
--- a/src/currencyEngineETH.js
+++ b/src/currencyEngineETH.js
@@ -1308,7 +1308,7 @@ class EthereumEngine {
 
     const InsufficientFundsError = new Error('Insufficient funds')
     InsufficientFundsError.name = 'ErrorInsufficientFunds'
-    const InsufficientFundsEthError = new Error('Insufficient funds. Need more ETH')
+    const InsufficientFundsEthError = new Error('Insufficient ETH for transaction fee')
     InsufficientFundsEthError.name = 'ErrorInsufficientFundsMoreEth'
 
     // Check for insufficient funds

--- a/src/currencyEngineETH.js
+++ b/src/currencyEngineETH.js
@@ -1307,7 +1307,9 @@ class EthereumEngine {
     }
 
     const InsufficientFundsError = new Error('Insufficient funds')
-    InsufficientFundsError.name = 'InsufficientFundsError'
+    InsufficientFundsError.name = 'ErrorInsufficientFunds'
+    const InsufficientFundsEthError = new Error('Insufficient funds. Need more ETH')
+    InsufficientFundsEthError.name = 'ErrorInsufficientFundsMoreEth'
 
     // Check for insufficient funds
     // let nativeAmountBN = new BN(nativeAmount, 10)
@@ -1327,6 +1329,9 @@ class EthereumEngine {
       }
       nativeAmount = bns.mul(totalTxAmount, '-1')
     } else {
+      if (bns.gt(nativeNetworkFee, balanceEth)) {
+        throw (InsufficientFundsEthError)
+      }
       nativeNetworkFee = '0' // Do not show a fee for token transations.
       const balanceToken = this.walletLocalData.totalBalances[currencyCode]
       if (bns.gt(nativeAmount, balanceToken)) {


### PR DESCRIPTION
This display an error message to the user during amount entry instead of just failing the transaction on Send.