### PR TITLE
Bump version: Include token_info as prefix for AddToken scan QR code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edge-currency-ethereum",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Edge Ethereum currency plugin",
   "homepage": "https://edgesecure.co/",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
The purpose is to bump this version to include the `token_info` prefix for addToken scan functionality